### PR TITLE
Fix to skip file which is over the size 50 Mbytes.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,14 +52,14 @@ install-sosreport_analyzer_data:
             $(INSTALL) -m 644 $(srcdir)/sosreport-analyzer-mcinfo.conf.example $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH)/sosreport-analyzer-mcinfo.conf.example; \
             $(INSTALL) -m 644 $(srcdir)/conf/sosreport-analyzer.conf.CentOS7.example $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH)/sosreport-analyzer.conf.CentOS7.example; \
             $(INSTALL) -m 644 $(srcdir)/conf/sosreport-analyzer.conf.CentOS6.example $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH)/sosreport-analyzer.conf.CentOS6.example; \
-            $(INSTALL) -m 644 $(srcdir)/conf/sosreport-analyzer-mcinfo.conf.AXS6.example $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH)/sosreport-analyzer-mcinfo.conf.AXS6.example; \
+            $(INSTALL) -m 644 $(srcdir)/conf/sosreport-analyzer-mcinfo.conf.AXS4.example $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH)/sosreport-analyzer-mcinfo.conf.AXS4.example; \
 	else \
             $(MKDIR_P) $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH); \
             $(INSTALL) -m 644 $(srcdir)/sosreport-analyzer.conf.example $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH)/sosreport-analyzer.conf.example; \
             $(INSTALL) -m 644 $(srcdir)/sosreport-analyzer-mcinfo.conf.example $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH)/sosreport-analyzer-mcinfo.conf.example; \
             $(INSTALL) -m 644 $(srcdir)/conf/sosreport-analyzer.conf.CentOS7.example $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH)/sosreport-analyzer.conf.CentOS7.example; \
             $(INSTALL) -m 644 $(srcdir)/conf/sosreport-analyzer.conf.CentOS6.example $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH)/sosreport-analyzer.conf.CentOS6.example; \
-            $(INSTALL) -m 644 $(srcdir)/conf/sosreport-analyzer-mcinfo.conf.AXS6.example $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH)/sosreport-analyzer-mcinfo.conf.AXS6.example; \
+            $(INSTALL) -m 644 $(srcdir)/conf/sosreport-analyzer-mcinfo.conf.AXS4.example $(DESTDIR)$(SOSREPORT_ANALYZER_DATA_PATH)/sosreport-analyzer-mcinfo.conf.AXS4.example; \
 	fi
 
 uninstall-sosreport_analyzer_data:

--- a/conf/sosreport-analyzer-mcinfo.conf.AXS4.example
+++ b/conf/sosreport-analyzer-mcinfo.conf.AXS4.example
@@ -2,7 +2,7 @@
 #
 # If you have installed this program before, new version will not override.
 #
-# Please check /usr/share/sosreport-analyzer/sosreport-analyzer-mcinfo.conf.AXS6.example, and
+# Please check /usr/share/sosreport-analyzer/sosreport-analyzer-mcinfo.conf.AXS4.example, and
 # copy it as /etc/sosreport-analyzer-mcinfo.conf.
 #
 #

--- a/conf/sosreport-analyzer.conf.CentOS6.example
+++ b/conf/sosreport-analyzer.conf.CentOS6.example
@@ -163,7 +163,7 @@ ps=all
 ## You can set arbitrary item-name including 'all' up to 12
 ## ex. lsof=bash 
 
-lsof=all
+lsof=bash
 
 ## netstat 
 ##

--- a/conf/sosreport-analyzer.conf.CentOS7.example
+++ b/conf/sosreport-analyzer.conf.CentOS7.example
@@ -163,7 +163,7 @@ ps=all
 ## You can set arbitrary item-name including 'all' up to 12
 ## ex. lsof=bash 
 
-lsof=all
+lsof=bash
 
 ## netstat 
 ##

--- a/sosreport-analyzer-mcinfo.conf.example
+++ b/sosreport-analyzer-mcinfo.conf.example
@@ -1,1 +1,1 @@
-conf/sosreport-analyzer-mcinfo.conf.AXS6.example
+conf/sosreport-analyzer-mcinfo.conf.AXS4.example


### PR DESCRIPTION
	modified:   Makefile.am
	renamed:    conf/sosreport-analyzer-mcinfo.conf.AXS6.example -> conf/sosreport-analyzer-mcinfo.conf.AXS4.example
	modified:   conf/sosreport-analyzer.conf.CentOS6.example
	modified:   conf/sosreport-analyzer.conf.CentOS7.example
	modified:   libsosreport-analyzer/common.c
	modified:   sosreport-analyzer-mcinfo.conf.example