### PR TITLE
Fix to check item string length for each member

### DIFF
--- a/common/global.h
+++ b/common/global.h
@@ -42,6 +42,12 @@
 /* the maximum size of analyze file */
 #define MAX_ANALYZE_FILE_SIZE 5242880 
 
+/* the minimum string length of the item for member */
+#define MIN_ITEM_STRING_LENGTH 2 
+
+/* the maximum string length of the item for member */
+#define MAX_ITEM_STRING_LENGTH 10 
+
 /*
  * reverse_the_string()
  *

--- a/libsosreport-analyzer/common.c
+++ b/libsosreport-analyzer/common.c
@@ -1142,6 +1142,22 @@ int read_file ( const char *file_name, const char *member, int files )
     return ( 0 );
 }
 
+int check_item_string_length ( const char *token, const char *member )
+{
+    int strlen_token = ( int ) strlen ( token );
+    if ( strlen_token > MAX_ITEM_STRING_LENGTH ) 
+    {
+        printf("item '%s' for '%s' is too long (%d)\n",token,member,strlen_token);
+        return ( 1 );
+    }
+    if ( strlen_token < MIN_ITEM_STRING_LENGTH ) 
+    {
+        printf("item '%s' for '%s' is too short (%d)\n",token,member,strlen_token);
+        return ( 1 );
+    }
+    return ( 0 );
+}
+
 int set_token_to_item_arr ( const char *file_name, const char *member )
 {
     /* These are array number limits for items of a member. */
@@ -1162,6 +1178,11 @@ int set_token_to_item_arr ( const char *file_name, const char *member )
     {
         /* get the first token */
         token = strtok ( get_items_of_member ( member ), s );
+        if ( check_item_string_length ( token, member ) != 0 )
+        {
+            free_sosreport_analyzer_obj ( );
+            exit ( EXIT_FAILURE );
+        }
         set_item_arr_string ( member, 0, token );
 
         if ( strcmp ( token, "all" ) == 0 )
@@ -1171,6 +1192,11 @@ int set_token_to_item_arr ( const char *file_name, const char *member )
             /* get the next token ... */
             while ( token != NULL )
             {
+                if ( check_item_string_length ( token, member ) != 0 )
+                {
+                    free_sosreport_analyzer_obj ( );
+                    exit ( EXIT_FAILURE );
+                }
                 if ( strcmp ( token, "all" ) == 0 )
                     break;
                 set_item_numbers_of_member ( member, i ); 

--- a/libsosreport-analyzer/common.h
+++ b/libsosreport-analyzer/common.h
@@ -302,4 +302,12 @@ int append_item_to_sos_line_obj ( char *line, const char *member, const char *it
  */
 void free_sosreport_analyzer_obj ( void );
 
+/*
+ * check_item_string_length ()
+ *
+ * This function checks item string length in the conf file 
+ *
+ */
+int check_item_string_length ( const char *token, const char *member );
+
 #endif /* SOSREPORT_ANALYZER_COMMON_H */


### PR DESCRIPTION
	modified:   common/global.h
	modified:   libsosreport-analyzer/common.c
	modified:   libsosreport-analyzer/common.h